### PR TITLE
use http over stdio to update config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cddc5f91628367664cc7c69714ff08deee8a3efc54623011c772544d7b2767"
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +948,7 @@ name = "tproxy"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -375,6 +375,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
+name = "json-patch"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f995a3c8f2bc3dd52a18a583e90f9ec109c047fa1603a853e46bcda14d2e279d"
+dependencies = [
+ "serde",
+ "serde_json",
+ "treediff",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,9 +438,9 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "mio"
@@ -664,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "a068b905b8cb93815aa3069ae48653d90f382308aebd1d33d940ac1f1d771e2d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -685,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "00efb87459ba4f6fb2169d20f68565555688e1250ee6825cdf6254f8b48fafb2"
 
 [[package]]
 name = "ryu"
@@ -932,8 +943,10 @@ dependencies = [
  "humantime-serde",
  "hyper",
  "iptables",
+ "json-patch",
  "libc",
  "paw",
+ "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1031,6 +1044,15 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "treediff"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761e8d5ad7ce14bb82b7e61ccc0ca961005a275a060b9644a2431aa11553c2ff"
+dependencies = [
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,6 @@ dependencies = [
  "json-patch",
  "libc",
  "paw",
- "regex",
  "serde",
  "serde_derive",
  "serde_json",
@@ -959,6 +958,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "wildmatch",
 ]
 
 [[package]]
@@ -1100,6 +1100,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c48bd20df7e4ced539c12f570f937c6b4884928a87fee70a479d72f031d4e0"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ serde_yaml = "0.8"
 socket2 = "0.3"
 structopt = {version = "0.3", features = ["paw"]}
 tokio = {version = "1.4", features = ["full"]}
-regex = "1.5"
+wildmatch = "2.1"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,11 @@ serde_yaml = "0.8"
 socket2 = "0.3"
 structopt = {version = "0.3", features = ["paw"]}
 tokio = {version = "1.4", features = ["full"]}
+regex = "1.5"
 tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
+json-patch = "0.2.6"
 
 [dev-dependencies]
 test-case = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2"
 json-patch = "0.2.6"
+async-trait = "0.1.50"
 
 [dev-dependencies]
 test-case = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = "2.33.3"
 futures = "0.3.10"
 http = "0.2.3"
 humantime-serde = "1.0"
-hyper = {version = "0.14.4", features = ["runtime", "client", "server", "http1", "http2"]}
+hyper = {version = "0.14.4", features = ["runtime", "client", "server", "http1", "http2", "stream"]}
 iptables = "0.4"
 libc = {version = "0.2.81", features = ["std"]}
 paw = "1.0"

--- a/README.md
+++ b/README.md
@@ -10,17 +10,19 @@ Usage Example:
 
 ```
 proxy 0.1.0
-The option of tproxy.
+The option of rs-proxy.
 
 USAGE:
-    tproxy <input>
+    tproxy [FLAGS] [FILE]
 
 FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    -h, --help           Prints help information
+    -i, --interactive    Allows to apply config by stdin/stdout
+    -V, --version        Prints version information
+    -v, --verbose        Verbose mode (-v, -vv, -vvv, etc.)
 
 ARGS:
-    <input>    path of config file
+    <FILE>    path of config file, required if interactive mode is disabled
 ```
 Support json and yaml config. Example of config could be found in `./example/config`
 
@@ -34,3 +36,51 @@ make build
 ```bash
 make run config=<path>
 ```
+
+### interactive mode
+
+You can apply config by HTTP over stdio if interactive mode is enabled.
+
+- apply
+
+```bash
+> sudo target/release/tproxy -i
+PUT / HTTP/1.1
+Content-Length: 129
+
+{"proxy_ports": [30086], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
+```
+
+- get the response:
+
+```bash
+HTTP/1.1 200 OK
+content-length: 0
+date: Mon, 03 May 2021 11:21:31 GMT
+```
+
+- recover
+
+> Update config with empty proxy ports.
+
+```
+PUT / HTTP/1.1
+Content-Length: 129
+
+{"proxy_ports": [30086], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
+HTTP/1.1 200 OK
+content-length: 0
+date: Mon, 03 May 2021 11:21:31 GMT
+
+PUT / HTTP/1.1
+Content-Length: 124
+
+{"proxy_ports": [], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
+HTTP/1.1 200 OK
+content-length: 0
+date: Mon, 03 May 2021 11:22:13 GMT
+```
+
+- exit
+
+Ctrl-C

--- a/config-examples/json_example.json
+++ b/config-examples/json_example.json
@@ -12,7 +12,7 @@
       },
       "actions": {
         "delay": "10s",
-        "append": {
+        "patch": {
           "queries": [
             ["foo", "bar"],
             ["foo", "other"]

--- a/config-examples/yaml_example.yaml
+++ b/config-examples/yaml_example.yaml
@@ -10,7 +10,7 @@ rules:
       method: GET
     actions:
       delay: 10s 
-      append:
+      patch:
         queries:
         - [foo, bar]
         - [foo, other]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -23,8 +23,8 @@ pub struct Opt {
     #[structopt(short, long, parse(from_occurrences))]
     verbose: u8,
 
-    /// path of config file
-    #[structopt(name = "FILE", parse(from_os_str), required_if("interactive", "false"))]
+    /// path of config file, required if interactive mode is disabled
+    #[structopt(name = "FILE", parse(from_os_str))]
     input: Option<PathBuf>,
 }
 
@@ -36,6 +36,17 @@ impl Opt {
             2 => LevelFilter::DEBUG,
             _ => LevelFilter::TRACE,
         }
+    }
+
+    pub fn from_args_checked() -> Result<Self> {
+        Self::from_args_safe()?.checked()
+    }
+
+    fn checked(self) -> Result<Self> {
+        if !self.interactive && self.input.is_none() {
+            return Err(anyhow!("config file is required when interactive mode is disabled, use `-h | --help` for more details"));
+        }
+        Ok(self)
     }
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -16,16 +16,16 @@ pub mod config;
 pub struct Opt {
     /// Allows to apply config by stdin/stdout
     #[structopt(short, long)]
-    interactive: bool,
+    pub interactive: bool,
 
     // The number of occurrences of the `v/verbose` flag
     /// Verbose mode (-v, -vv, -vvv, etc.)
     #[structopt(short, long, parse(from_occurrences))]
-    verbose: u8,
+    pub verbose: u8,
 
     /// path of config file, required if interactive mode is disabled
     #[structopt(name = "FILE", parse(from_os_str))]
-    input: Option<PathBuf>,
+    pub input: Option<PathBuf>,
 }
 
 impl Opt {
@@ -50,11 +50,11 @@ impl Opt {
     }
 }
 
-pub async fn get_config_from_opt(opt: Opt) -> Result<Config> {
+pub async fn get_config_from_opt(opt: &Opt) -> Result<Config> {
     match opt.input {
         None => RawConfig::default(),
-        Some(path_buf) => {
-            let buffer = read_to_string(&path_buf).await?;
+        Some(ref path_buf) => {
+            let buffer = read_to_string(path_buf).await?;
             match path_buf.extension().and_then(|ext| ext.to_str()) {
                 Some("json") => serde_json::from_str(&buffer)?,
                 Some("yaml") => serde_yaml::from_str(&buffer)?,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -72,8 +72,8 @@ mod test {
                     actions: RawActions {
                         abort: None,
                         delay: Some(Duration::from_secs(1)),
-                        append: None,
                         replace: None,
+                        patch: None,
                     },
                 },
                 RawRule {
@@ -99,8 +99,8 @@ mod test {
                     actions: RawActions {
                         abort: Some(true),
                         delay: Some(Duration::from_secs(1)),
-                        append: None,
                         replace: None,
+                        patch: None,
                     },
                 },
             ]),

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
@@ -6,6 +7,7 @@ use anyhow::{anyhow, Error};
 use http::header::{HeaderMap, HeaderName};
 use http::StatusCode;
 use serde::{Deserialize, Serialize};
+use wildmatch::WildMatch;
 
 use crate::handler::{
     Actions, PatchAction, PatchBodyAction, ReplaceAction, Rule, Selector, Target,
@@ -157,7 +159,7 @@ impl TryFrom<RawSelector> for Selector {
     fn try_from(raw: RawSelector) -> Result<Self, Self::Error> {
         Ok(Self {
             port: raw.port.clone(),
-            path: raw.path.as_ref().map(|path| path.parse()).transpose()?,
+            path: raw.path.as_ref().map(|p| WildMatch::new(&p)),
             method: raw
                 .method
                 .as_ref()

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
@@ -40,6 +39,8 @@ pub enum RawTarget {
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 pub struct RawSelector {
     pub port: Option<u16>,
+
+    // [wildcard matches](https://www.wikiwand.com/en/Matching_wildcards)
     pub path: Option<String>,
     pub method: Option<String>,
     pub code: Option<u16>,

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -49,8 +49,8 @@ pub struct RawActions {
     #[serde(default)]
     #[serde(with = "humantime_serde")]
     pub delay: Option<Duration>,
-    pub append: Option<RawAppendAction>,
     pub replace: Option<RawReplaceAction>,
+    pub append: Option<RawAppendAction>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]

--- a/src/cmd/config.rs
+++ b/src/cmd/config.rs
@@ -182,8 +182,8 @@ impl TryFrom<RawActions> for Actions {
         Ok(Self {
             abort: raw.abort.unwrap_or(false),
             delay: raw.delay,
-            append: raw.append.map(TryInto::try_into).transpose()?,
             replace: raw.replace.map(TryInto::try_into).transpose()?,
+            append: raw.append.map(TryInto::try_into).transpose()?,
         })
     }
 }

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -1,0 +1,10 @@
+mod accept;
+mod stream;
+
+use self::accept::accept_std_stream;
+use self::stream::StdStream;
+use crate::server_helper::ServeHandler;
+
+pub struct ConfigServer {
+    handler: Option<ServeHandler>,
+}

--- a/src/config_server.rs
+++ b/src/config_server.rs
@@ -1,10 +1,143 @@
 mod accept;
 mod stream;
 
+use std::convert::{Infallible, TryInto};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use anyhow::anyhow;
+use futures::{pin_mut, select, FutureExt, TryStreamExt};
+use http::{Method, Request, Response, StatusCode};
+use hyper::service::Service;
+use hyper::{Body, Server};
+use tokio::sync::Mutex;
+use tracing::instrument;
+
 use self::accept::accept_std_stream;
 use self::stream::StdStream;
-use crate::server_helper::ServeHandler;
+use crate::server_helper::{BoxedSendFuture, ServeHandler};
+use crate::tproxy::config::Config;
+use crate::{tproxy, RawConfig};
 
 pub struct ConfigServer {
+    tproxy_server: Arc<Mutex<tproxy::HttpServer>>,
     handler: Option<ServeHandler>,
+}
+
+impl ConfigServer {
+    pub fn watch(tproxy_server: tproxy::HttpServer) -> Self {
+        Self {
+            tproxy_server: Arc::new(Mutex::new(tproxy_server)),
+            handler: None,
+        }
+    }
+
+    pub async fn start(&mut self) -> anyhow::Result<()> {
+        if self.handler.is_some() {
+            return Err(anyhow!("there is already a config server running"));
+        }
+
+        let server = Server::builder(accept_std_stream())
+            .http1_keepalive(true)
+            .serve(ServerImpl(self.tproxy_server.clone()));
+        self.handler = Some(ServeHandler::serve(move |rx| async move {
+            let rx = rx.fuse();
+            let server = server.fuse();
+            pin_mut!(rx);
+            pin_mut!(server);
+            select! {
+                signal = rx => signal.map_err::<anyhow::Error, _>(Into::into),
+                ret = server => ret.map_err(Into::into),
+            }
+        }));
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> anyhow::Result<()> {
+        self.tproxy_server.lock().await.stop().await?;
+        match self.handler.take() {
+            None => return Err(anyhow!("there is no config server running")),
+            Some(handler) => handler.stop().await,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ServerImpl(Arc<Mutex<tproxy::HttpServer>>);
+
+impl ServerImpl {
+    async fn read_config(request: Request<Body>) -> anyhow::Result<Config> {
+        let request_data: Vec<u8> = request
+            .into_body()
+            .try_fold(vec![], |mut data, seg| {
+                data.extend(seg);
+                futures::future::ok(data)
+            })
+            .await?;
+
+        let raw_config: RawConfig = serde_json::from_slice(&request_data)?;
+        raw_config.try_into()
+    }
+
+    #[instrument]
+    async fn handle(
+        handler: &mut tproxy::HttpServer,
+        request: Request<Body>,
+    ) -> anyhow::Result<Response<Body>> {
+        if request.method() != Method::PUT {
+            return Ok(Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .body(Body::empty())?);
+        }
+
+        let config = Self::read_config(request).await;
+
+        if let Err(err) = config {
+            return Ok(Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(err.to_string().into())?);
+        }
+
+        if let Err(err) = handler.reload(config.unwrap()).await {
+            return Ok(Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(err.to_string().into())?);
+        }
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())?)
+    }
+}
+
+impl Service<&StdStream> for ServerImpl {
+    type Response = Self;
+    type Error = Infallible;
+    type Future = BoxedSendFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, _: &StdStream) -> Self::Future {
+        let service = self.clone();
+        Box::pin(async move { Ok(service) })
+    }
+}
+
+impl Service<Request<Body>> for ServerImpl {
+    type Response = Response<Body>;
+    type Error = anyhow::Error;
+    type Future = BoxedSendFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let handler = self.0.clone();
+        Box::pin(async move { Self::handle(&mut *handler.lock().await, request).await })
+    }
 }

--- a/src/config_server/accept.rs
+++ b/src/config_server/accept.rs
@@ -1,0 +1,10 @@
+use std::task::Poll;
+
+use hyper::server::accept::{poll_fn, Accept};
+
+use super::stream::StdStream;
+
+pub fn accept_std_stream() -> impl Accept {
+    let mut stream = Some(StdStream::default());
+    poll_fn(move |_| Poll::Ready(stream.take().map(Ok::<_, ()>)))
+}

--- a/src/config_server/accept.rs
+++ b/src/config_server/accept.rs
@@ -1,10 +1,11 @@
+use std::convert::Infallible;
 use std::task::Poll;
 
 use hyper::server::accept::{poll_fn, Accept};
 
 use super::stream::StdStream;
 
-pub fn accept_std_stream() -> impl Accept {
+pub fn accept_std_stream() -> impl Accept<Conn = StdStream, Error = Infallible> {
     let mut stream = Some(StdStream::default());
-    poll_fn(move |_| Poll::Ready(stream.take().map(Ok::<_, ()>)))
+    poll_fn(move |_| Poll::Ready(stream.take().map(Ok)))
 }

--- a/src/config_server/stream.rs
+++ b/src/config_server/stream.rs
@@ -1,0 +1,57 @@
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf, Stdin, Stdout};
+
+#[derive(Debug)]
+pub struct StdStream {
+    stdin: Stdin,
+    stdout: Stdout,
+}
+
+impl StdStream {
+    fn new() -> Self {
+        Self {
+            stdin: tokio::io::stdin(),
+            stdout: tokio::io::stdout(),
+        }
+    }
+}
+
+impl AsyncRead for StdStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.stdin).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for StdStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.stdout).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.stdout).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        Pin::new(&mut self.stdout).poll_shutdown(cx)
+    }
+}
+
+impl Default for StdStream {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,19 +6,15 @@ pub mod server_helper;
 pub mod signal;
 pub mod tproxy;
 
-use std::convert::TryInto;
-
 use anyhow::anyhow;
 use cmd::config::RawConfig;
 use cmd::get_config;
-use futures::future::FutureExt;
-use futures::{pin_mut, select};
 use signal::SignalHandler;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::signal::unix::SignalKind;
-use tproxy::HttpServer;
-use tracing::error;
 use tracing_subscriber::EnvFilter;
+
+use crate::config_server::ConfigServer;
+use crate::tproxy::HttpServer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -29,41 +25,15 @@ async fn main() -> anyhow::Result<()> {
         .map_err(|err| anyhow!("{}", err))?;
 
     let cfg = get_config().await?;
-    let mut server = HttpServer::new(cfg);
-    server.start().await?;
+    let mut tproxy_server = HttpServer::new(cfg);
+    tproxy_server.start().await?;
+
+    let mut config_server = ConfigServer::watch(tproxy_server);
+    config_server.start().await?;
 
     let mut signal_handler =
         SignalHandler::from_kinds(&[SignalKind::interrupt(), SignalKind::terminate()])?;
-    let signal_recv = signal_handler.wait().fuse();
-    pin_mut!(signal_recv);
-
-    let mut stdin = BufReader::new(tokio::io::stdin());
-    loop {
-        let mut buf = String::new();
-        let read_line = stdin.read_line(&mut buf).fuse();
-        pin_mut!(read_line);
-
-        select! {
-            _ = signal_recv => break,
-            read_ret = read_line => {
-                if let Err(err) = read_ret {
-                    error!("error in receiving new config: {}", err);
-                    break;
-                }
-                if let Err(err) = reload(&mut server, &buf).await {
-                    error!("error in reloading http server: {}", err);
-                    break;
-                }
-            }
-        };
-    }
-
-    server.stop().await?;
-    Ok(())
-}
-
-async fn reload(server: &mut HttpServer, buf: &str) -> anyhow::Result<()> {
-    let cfg = serde_json::from_str::<RawConfig>(buf)?;
-    server.reload(cfg.try_into()?).await?;
+    signal_handler.wait().await?;
+    config_server.stop().await?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,6 @@ pub mod signal;
 pub mod tproxy;
 
 use anyhow::anyhow;
-use structopt::StructOpt;
 use tokio::signal::unix::SignalKind;
 
 use crate::cmd::config::RawConfig;
@@ -18,7 +17,7 @@ use crate::tproxy::HttpServer;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let opt = Opt::from_args_safe()?;
+    let opt = Opt::from_args_checked()?;
     tracing_subscriber::fmt()
         .with_max_level(opt.get_level_filter())
         .with_writer(std::io::stderr)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 pub mod cmd;
+pub mod config_server;
 pub mod handler;
 pub mod route;
+pub mod server_helper;
 pub mod signal;
 pub mod tproxy;
 
@@ -22,6 +24,7 @@ use tracing_subscriber::EnvFilter;
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
         .try_init()
         .map_err(|err| anyhow!("{}", err))?;
 

--- a/src/server_helper.rs
+++ b/src/server_helper.rs
@@ -1,9 +1,11 @@
 use std::future::Future;
+use std::pin::Pin;
 
 use futures::TryFutureExt;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 use tokio::task::{spawn, JoinHandle};
 
+#[derive(Debug)]
 pub struct ServeHandler {
     sender: Sender<()>,
     handler: JoinHandle<anyhow::Result<()>>,
@@ -28,3 +30,5 @@ impl ServeHandler {
         Ok(())
     }
 }
+
+pub type BoxedSendFuture<T, E> = Pin<Box<dyn 'static + Send + Future<Output = Result<T, E>>>>;

--- a/src/server_helper.rs
+++ b/src/server_helper.rs
@@ -1,9 +1,16 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use async_trait::async_trait;
 use futures::TryFutureExt;
 use tokio::sync::oneshot::{channel, Receiver, Sender};
 use tokio::task::{spawn, JoinHandle};
+
+#[async_trait]
+pub trait SuperServer {
+    async fn start(&mut self) -> anyhow::Result<()>;
+    async fn stop(&mut self) -> anyhow::Result<()>;
+}
 
 #[derive(Debug)]
 pub struct ServeHandler {

--- a/src/server_helper.rs
+++ b/src/server_helper.rs
@@ -1,0 +1,30 @@
+use std::future::Future;
+
+use futures::TryFutureExt;
+use tokio::sync::oneshot::{channel, Receiver, Sender};
+use tokio::task::{spawn, JoinHandle};
+
+pub struct ServeHandler {
+    sender: Sender<()>,
+    handler: JoinHandle<anyhow::Result<()>>,
+}
+
+impl ServeHandler {
+    pub fn serve<F, R, E>(with_signal: F) -> Self
+    where
+        F: FnOnce(Receiver<()>) -> R,
+        R: 'static + Send + Future<Output = Result<(), E>>,
+        E: 'static + Send + Into<anyhow::Error>,
+    {
+        let (sender, rx) = channel();
+        let handler = spawn(with_signal(rx).map_err(Into::into));
+        Self { sender, handler }
+    }
+
+    pub async fn stop(self) -> anyhow::Result<()> {
+        let ServeHandler { sender, handler } = self;
+        let _ = sender.send(());
+        let _ = handler.await??;
+        Ok(())
+    }
+}

--- a/src/tproxy.rs
+++ b/src/tproxy.rs
@@ -13,14 +13,14 @@ use http::StatusCode;
 use hyper::service::Service;
 use hyper::{Body, Client, Request, Response, Server};
 use tokio::net::TcpStream;
-use tokio::sync::oneshot::{channel, Sender};
-use tokio::task::{spawn, spawn_blocking, JoinHandle};
-use tracing::{debug, error, info, instrument};
+use tokio::task::spawn_blocking;
+use tracing::{debug, error, instrument};
 
 use crate::handler::{
     apply_request_action, apply_response_action, select_request, select_response, Target,
 };
 use crate::route::{clear_routes, set_all_routes};
+use crate::server_helper::ServeHandler;
 
 pub mod config;
 pub mod connector;
@@ -35,41 +35,11 @@ pub struct HttpServer {
 
 struct ServerImpl(Arc<Config>);
 
-struct ServeHandler {
-    sender: Sender<()>,
-    handler: JoinHandle<()>,
-}
-
 #[derive(Debug, Clone)]
 pub struct HttpService {
     target: SocketAddr,
     config: Arc<Config>,
     client: Arc<Client<HttpConnector>>,
-}
-
-impl ServeHandler {
-    fn serve(server: Server<TcpIncoming, ServerImpl>) -> Self {
-        let (sender, rx) = channel();
-        let handler = spawn(async move {
-            // Await the `server` receiving the signal...
-            if let Err(e) = server
-                .with_graceful_shutdown(async move {
-                    rx.await.ok();
-                })
-                .await
-            {
-                info!("server error: {}", e);
-            }
-        });
-        Self { sender, handler }
-    }
-
-    async fn stop(self) -> Result<()> {
-        let ServeHandler { sender, handler } = self;
-        let _ = sender.send(());
-        let _ = handler.await?;
-        Ok(())
-    }
 }
 
 impl HttpServer {
@@ -96,7 +66,11 @@ impl HttpServer {
         .await??;
 
         let server = Server::builder(incoming).serve(ServerImpl(Arc::new(self.config.clone())));
-        self.handler = Some(ServeHandler::serve(server));
+        self.handler = Some(ServeHandler::serve(move |rx| {
+            server.with_graceful_shutdown(async move {
+                rx.await.ok();
+            })
+        }));
         Ok(())
     }
 

--- a/src/tproxy/connector.rs
+++ b/src/tproxy/connector.rs
@@ -11,7 +11,8 @@ use tokio::net::{TcpSocket, TcpStream};
 use tracing::{instrument, trace};
 
 use super::config::Config;
-use super::{socketopt, BoxedFuture};
+use super::socketopt;
+use crate::server_helper::BoxedSendFuture;
 
 #[derive(Debug, Clone)]
 pub struct HttpConnector {
@@ -41,7 +42,7 @@ impl HttpConnector {
 impl Service<Uri> for HttpConnector {
     type Response = TcpStream;
     type Error = Error;
-    type Future = BoxedFuture<Self::Response, Self::Error>;
+    type Future = BoxedSendFuture<Self::Response, Self::Error>;
 
     #[instrument]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/src/tproxy/listener.rs
+++ b/src/tproxy/listener.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, instrument, trace};
 
 use super::socketopt;
 /// A stream of connections from binding to an address.
-/// As an implementation of roa_core::Accept.
+/// As an implementation of `hyper::server::accept::Accept`.
 #[must_use = "streams do nothing unless polled"]
 pub struct TcpIncoming {
     addr: SocketAddr,


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

### Features

- use HTTP over stdio to update config
As mentioned in [chaos-mesh#1706](https://github.com/chaos-mesh/chaos-mesh/pull/1706#discussion_r621766031), we need the update result from stdio.

- ensure actions order
As mentioned in [chaos-mesh#1706](https://github.com/chaos-mesh/chaos-mesh/pull/1706#discussion_r623610580), we should ensure the order of the action applied.

- rename append action to patch action; support json merge patch as [rfc7396](https://tools.ietf.org/html/rfc7396)

- support wildcard URI path as rules of [wildcard matches](https://www.wikiwand.com/en/Matching_wildcards).

### HTTP over stdio usage

#### Build
```bash
> cargo build --release
```

#### Run and apply config
```bash
> sudo target/release/tproxy -i
PUT / HTTP/1.1
Content-Length: 129

{"proxy_ports": [30086], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
```

get the response:

```bash
HTTP/1.1 200 OK
content-length: 0
date: Mon, 03 May 2021 11:21:31 GMT
```

#### Recover
> Update config with empty proxy ports.

```
PUT / HTTP/1.1
Content-Length: 129

{"proxy_ports": [30086], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
HTTP/1.1 200 OK
content-length: 0
date: Mon, 03 May 2021 11:21:31 GMT

PUT / HTTP/1.1
Content-Length: 124

{"proxy_ports": [], "rules": [{"target": "Request", "selector": {"path": "*", "method": "GET"},"actions": {"abort": true}}]}
HTTP/1.1 200 OK
content-length: 0
date: Mon, 03 May 2021 11:22:13 GMT
```

#### Exit
Ctrl-C