### PR TITLE
Fix bug in help message & Fix bug when using ip command in old version & Update doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,77 @@
 # rs-tproxy
 
-Transparent proxy in only linux 2.0+ platform for injecting [Abort|Delay|Append|Replace] HTTP packet.
+Transparent HTTP proxy for [Abort|Delay|Append|Replace] packet.
+Based on linux iptables-extension : TPROXY.
 
-Based on linux iptables-tproxy method, the proxy do not need any L3|L4 config ( An valid local port is needed ). 
+## Installation
+### Install ebtables-legacy
+Rs-tproxy relies on the legacy version of ebtables since the ebtables-nft have some problem on brouting transfer.
+So on different linux distribution we need to install ebtables-legacy or create a symbolic link.
+#### On centos 7.0 - 7.9 or other version using legacy version of ebtables:
+```
+ln -s /usr/sbin/ebtables /usr/sbin/ebtables-legacy
+```
+#### On centos 8+ :
+```
+wget http://mirror.coastal.edu/centos/8-stream/hyperscale/x86_64/packages-main/Packages/e/ebtables-legacy-2.0.11-9.hs.el8.x86_64.rpm
+rpm -i ebtables-legacy-2.0.11-9.hs.el8.x86_64.rpm
+rm ebtables-legacy-2.0.11-9.hs.el8.x86_64.rpm
+yum reinstall iptables-ebtables
+```
+#### On Debian or Ubuntu :
+```
+apt install -y ebtables
+```
+### Install rs-tproxy
 
-You can run it as the proxy for any ports on the same network namespace by set the `proxy_ports` field in config file.
+Download rs-tproxy in release.
 
-Usage Example:
+## Quick start
+
+```bash
+cat > example.yaml<<EOF
+proxy_ports: [80]
+rules:
+  - target: Request
+    selector:
+      method: GET
+    actions:
+      delay: 5s
+EOF
+rs-tproxy ./example.yaml -v
+```
+### Tips for ubuntu user:
+The DNS will be broken if you are using the dnsmasq server on 127.0.0.1:53.
+Please change the default dns server to 8.8.8.8 or other global dns server by editting `/etc/resolv.conf` after using `rs-tproxy`. 
+
+## Usage example: 
 
 ```
-proxy 0.1.0
-The option of rs-proxy.
+>rs-tproxy -h
+
+proxy 0.1.1
+The option of proxy.
 
 USAGE:
-    tproxy [FLAGS] [FILE]
+    rs-tproxy [FLAGS] [OPTIONS] [FILE]
 
 FLAGS:
     -h, --help           Prints help information
-    -i, --interactive    Allows to apply config by stdin/stdout
+    -i, --interactive    Allows applying json config by stdin/stdout
+        --proxy          Only run the sub proxy
     -V, --version        Prints version information
     -v, --verbose        Verbose mode (-v, -vv, -vvv, etc.)
 
+OPTIONS:
+        --ipc-path <ipc-path>    ipc path for sub proxy
+
 ARGS:
-    <FILE>    path of config file, required if interactive mode is disabled
+    <FILE>    path of config file, required if interactive and daemon mode is disabled
 ```
-Support json and yaml config. Example of config could be found in `./example/config`
+Support json and yaml config. 
+Example of config could be found in `./config-examples`
+todo: add config doc in https://github.com/chaos-mesh/website.
+
 
 ## Build:
 ```
@@ -36,6 +83,11 @@ make build
 ```bash
 make run config=<path>
 ```
+or 
+```
+rs-tproxy <configfilename> -v
+```
+
 
 ### interactive mode
 
@@ -44,7 +96,7 @@ You can apply config by HTTP over stdio if interactive mode is enabled.
 - apply
 
 ```bash
-> sudo target/release/tproxy -i
+> rs-tproxy -i
 PUT / HTTP/1.1
 Content-Length: 129
 

--- a/rs-tproxy-controller/src/cmd/command_line.rs
+++ b/rs-tproxy-controller/src/cmd/command_line.rs
@@ -11,7 +11,7 @@ use crate::raw_config::RawConfig;
 
 //todo: name & about. (need discussion)
 #[derive(Debug, StructOpt)]
-#[structopt(name = "proxy", about = "The option of rs-proxy.")]
+#[structopt(name = "proxy", about = "The option of proxy.")]
 pub struct Opt {
     /// path of config file, required if interactive and daemon mode is disabled
     #[structopt(name = "FILE", parse(from_os_str))]
@@ -20,14 +20,6 @@ pub struct Opt {
     /// Allows applying json config by stdin/stdout
     #[structopt(short, long)]
     pub interactive: bool,
-
-    /// Allows applying json config by http.
-    #[structopt(short, long)]
-    pub daemon: bool,
-
-    /// Port of daemon server. Default is a random port.
-    #[structopt(long)]
-    pub daemon_port: Option<u16>,
 
     // The number of occurrences of the `v/verbose` flag
     /// Verbose mode (-v, -vv, -vvv, etc.)
@@ -58,7 +50,7 @@ impl Opt {
     }
 
     fn checked(self) -> Result<Self> {
-        if !self.interactive && !self.daemon && !self.proxy && self.input.is_none() {
+        if !self.interactive && !self.proxy && self.input.is_none() {
             return Err(anyhow!("config file is required when interactive mode and daemon mode is all disabled, use `-h | --help` for more details"));
         }
         Ok(self)

--- a/rs-tproxy-controller/src/main.rs
+++ b/rs-tproxy-controller/src/main.rs
@@ -6,6 +6,7 @@ use tokio::signal::unix::SignalKind;
 use crate::cmd::command_line::{get_config_from_opt, Opt};
 use crate::cmd::interactive::handler::ConfigServer;
 use crate::proxy::exec::Proxy;
+use std::process::exit;
 
 pub mod cmd;
 pub mod proxy;
@@ -13,7 +14,13 @@ pub mod raw_config;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let opt = Opt::from_args_checked()?;
+    let opt = match Opt::from_args_checked() {
+        Err(e) => {
+            println!("{}",e.to_string());
+            exit(1)
+        }
+        Ok(o) => {o}
+    };
     tracing_subscriber::fmt()
         .with_max_level(opt.get_level_filter())
         .with_writer(std::io::stderr)

--- a/rs-tproxy-controller/src/main.rs
+++ b/rs-tproxy-controller/src/main.rs
@@ -1,3 +1,5 @@
+use std::process::exit;
+
 use anyhow::anyhow;
 use rs_tproxy_proxy::proxy_main;
 use rs_tproxy_proxy::signal::Signals;
@@ -6,7 +8,6 @@ use tokio::signal::unix::SignalKind;
 use crate::cmd::command_line::{get_config_from_opt, Opt};
 use crate::cmd::interactive::handler::ConfigServer;
 use crate::proxy::exec::Proxy;
-use std::process::exit;
 
 pub mod cmd;
 pub mod proxy;
@@ -16,10 +17,10 @@ pub mod raw_config;
 async fn main() -> anyhow::Result<()> {
     let opt = match Opt::from_args_checked() {
         Err(e) => {
-            println!("{}",e.to_string());
+            println!("{}", e.to_string());
             exit(1)
         }
-        Ok(o) => {o}
+        Ok(o) => o,
     };
     tracing_subscriber::fmt()
         .with_max_level(opt.get_level_filter())

--- a/rs-tproxy-controller/src/proxy/config.rs
+++ b/rs-tproxy-controller/src/proxy/config.rs
@@ -57,10 +57,12 @@ pub(crate) fn get_free_port(ports: Option<Vec<u16>>) -> anyhow::Result<u16> {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto;
+
+    use rs_tproxy_proxy::raw_config::RawConfig as ProxyRawConfig;
+
     use crate::proxy::config::{get_free_port, Config};
     use crate::raw_config::RawConfig;
-    use rs_tproxy_proxy::raw_config::RawConfig as ProxyRawConfig;
-    use std::convert::TryInto;
 
     #[test]
     fn test_get_free_port() {

--- a/rs-tproxy-controller/src/proxy/exec.rs
+++ b/rs-tproxy-controller/src/proxy/exec.rs
@@ -149,9 +149,15 @@ impl Proxy {
             self.sender = new.sender.take();
             self.rx = new.rx.take();
         }
-        if self.exec(config).await.is_err() {
-            self.net_env.clear_bridge()?;
+
+        return match self.exec(config).await {
+            Err(e) => {
+                self.net_env.clear_bridge()?;
+                Err(e)
+            }
+            Ok(_) => {
+                Ok(())
+            }
         }
-        Ok(())
     }
 }

--- a/rs-tproxy-controller/src/proxy/exec.rs
+++ b/rs-tproxy-controller/src/proxy/exec.rs
@@ -155,9 +155,7 @@ impl Proxy {
                 self.net_env.clear_bridge()?;
                 Err(e)
             }
-            Ok(_) => {
-                Ok(())
-            }
-        }
+            Ok(_) => Ok(()),
+        };
     }
 }

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -87,7 +87,6 @@ impl NetEnv {
         };
         let save = format!("ip route save table all > {}", &self.ip_route_store);
         let save_dns = "cp /etc/resolv.conf /etc/resolv.conf.bak";
-        let restore_dns = "mv /etc/resolv.conf.bak /etc/resolv.conf";
         let net: Ipv4Network = self.ip.parse().unwrap();
         let net_ip32 = net.ip().to_string() + "/32";
         let net_domain = Ipv4Addr::from(u32::from(net.ip()) & u32::from(net.mask())).to_string()
@@ -199,7 +198,6 @@ impl NetEnv {
                     "100",
                 ],
             ),
-            bash_c(restore_dns),
         ];
         execute_all_with_log_error(cmdvv)?;
         Ok(())
@@ -207,7 +205,7 @@ impl NetEnv {
 
     pub fn clear_bridge(&self) -> Result<()> {
         let restore = format!("ip route restore < {}", &self.ip_route_store);
-        let restore_dns = "mv /etc/resolv.conf.bak /etc/resolv.conf";
+        let restore_dns = "cp /etc/resolv.conf.bak /etc/resolv.conf";
         let remove_store = format!("rm -f {}", &self.ip_route_store);
         let cmdvv = vec![
             ip_netns_del(&self.netns),

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -199,7 +199,7 @@ impl NetEnv {
                 ],
             ),
         ];
-        execute_all_with_log_error(cmdvv)?;
+        execute_all(cmdvv)?;
         Ok(())
     }
 

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -43,9 +43,9 @@ impl NetEnv {
         let netns = prefix.clone() + "ns";
         let bridge1 = prefix.clone() + "b1";
         let veth1 = prefix.clone() + "v1";
-        let veth2 = prefix.clone() + "v2";
+        let veth2 = "veth0".to_string();
         let bridge2 = prefix.clone() + "b2";
-        let veth3 = prefix.clone() + "v3";
+        let veth3 = "veth1".to_string();
         let veth4 = prefix + "v4";
         let ip = get_ipv4(&device).unwrap();
         Self {
@@ -102,7 +102,7 @@ impl NetEnv {
             ip_link_add_bridge(&self.bridge1),
             ip_link_add_veth_peer(&self.veth1, None, &self.veth2, Some(&self.netns)),
             ip_netns(&self.netns, ip_link_add_bridge(&self.bridge2)),
-            ip_link_add_veth_peer(&self.veth3, Some(&self.netns), &self.veth4, None),
+            ip_link_add_veth_peer(&self.veth4, None, &self.veth3, Some(&self.netns)),
             ip_link_set_up(&self.bridge1),
             ip_link_set_up(&self.veth1),
             ip_netns(&self.netns, ip_link_set_up(&self.veth2)),

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -248,7 +248,7 @@ pub fn bash_c(cmd: &str) -> Vec<&str> {
 }
 
 pub fn ip_link_del_bridge(name: &str) -> Vec<&str> {
-    vec!["ip", "link", "delete", "name", name, "type", "bridge"]
+    vec!["ip", "link", "delete", "dev", name, "type", "bridge"]
 }
 
 pub fn ip_link_add_veth_peer<'a>(

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -1,12 +1,13 @@
+use std::net::Ipv4Addr;
 use std::process::Command;
 
-use crate::proxy::net::iptables::clear_ebtables;
 use anyhow::{anyhow, Result};
 use default_net;
 use pnet::datalink::NetworkInterface;
 use pnet::ipnetwork::{IpNetwork, Ipv4Network};
-use std::net::Ipv4Addr;
 use uuid::Uuid;
+
+use crate::proxy::net::iptables::clear_ebtables;
 
 #[derive(Debug, Clone)]
 pub struct NetEnv {
@@ -160,18 +161,9 @@ impl NetEnv {
                 &self.netns,
                 vec!["sysctl", "-w", "net.ipv4.ip_nonlocal_bind=1"],
             ),
-            ip_netns(
-                &self.netns,
-                vec!["sysctl", "-w", &rp_filter_br2],
-            ),
-            ip_netns(
-                &self.netns,
-                vec!["sysctl", "-w", &rp_filter_v2],
-            ),
-            ip_netns(
-                &self.netns,
-                vec!["sysctl", "-w", &rp_filter_v3],
-            ),
+            ip_netns(&self.netns, vec!["sysctl", "-w", &rp_filter_br2]),
+            ip_netns(&self.netns, vec!["sysctl", "-w", &rp_filter_v2]),
+            ip_netns(&self.netns, vec!["sysctl", "-w", &rp_filter_v3]),
             ip_netns(
                 &self.netns,
                 vec!["sysctl", "-w", "net.ipv4.conf.lo.rp_filter=0"],

--- a/rs-tproxy-controller/src/proxy/net/iptables.rs
+++ b/rs-tproxy-controller/src/proxy/net/iptables.rs
@@ -121,6 +121,8 @@ pub fn set_iptables<'a>(
             "PREROUTING",
             "-i",
             &net_env.device,
+            "-j",
+            "dnat",
             "--to-dst",
             device_mac,
             "--dnat-target",
@@ -204,7 +206,7 @@ pub fn set_iptables_safe<'a>(net_env: &'a NetEnv, device_mac: &'a str) -> Vec<Ve
             ],
         ),
         vec![
-            "ebtables-legacy",
+            "ebtables",
             "-t",
             "nat",
             "-A",

--- a/rs-tproxy-controller/src/proxy/net/iptables.rs
+++ b/rs-tproxy-controller/src/proxy/net/iptables.rs
@@ -211,6 +211,8 @@ pub fn set_iptables_safe<'a>(net_env: &'a NetEnv, device_mac: &'a str) -> Vec<Ve
             "PREROUTING",
             "-i",
             &net_env.device,
+            "-j",
+            "dnat",
             "--to-dst",
             device_mac,
             "--dnat-target",

--- a/rs-tproxy-controller/src/proxy/net/set_net.rs
+++ b/rs-tproxy-controller/src/proxy/net/set_net.rs
@@ -1,6 +1,6 @@
 use std::option::Option::Some;
 
-use crate::proxy::net::bridge::{execute_all, get_interface, NetEnv};
+use crate::proxy::net::bridge::{bash_c, execute_all, execute, get_interface, NetEnv};
 use crate::proxy::net::iptables::{set_iptables, set_iptables_safe};
 
 #[cfg(target_os = "linux")]
@@ -10,9 +10,10 @@ pub fn set_net(
     listen_port: u16,
     safe: bool,
 ) -> anyhow::Result<()> {
+
     net_env.setenv_bridge()?;
     let port = listen_port.to_string();
-
+    let restore_dns = "cp /etc/resolv.conf.bak /etc/resolv.conf";
     let device_interface = get_interface(net_env.veth4.clone()).unwrap();
     let device_mac = device_interface.mac.unwrap().to_string();
 
@@ -25,7 +26,7 @@ pub fn set_net(
     if safe {
         execute_all(set_iptables_safe(net_env, &device_mac))?;
     }
-
+    let _ = execute(bash_c(restore_dns));
     Ok(())
 }
 

--- a/rs-tproxy-controller/src/proxy/net/set_net.rs
+++ b/rs-tproxy-controller/src/proxy/net/set_net.rs
@@ -1,6 +1,6 @@
 use std::option::Option::Some;
 
-use crate::proxy::net::bridge::{bash_c, execute_all, execute, get_interface, NetEnv};
+use crate::proxy::net::bridge::{bash_c, execute, execute_all, get_interface, NetEnv};
 use crate::proxy::net::iptables::{set_iptables, set_iptables_safe};
 
 #[cfg(target_os = "linux")]
@@ -10,7 +10,6 @@ pub fn set_net(
     listen_port: u16,
     safe: bool,
 ) -> anyhow::Result<()> {
-
     net_env.setenv_bridge()?;
     let port = listen_port.to_string();
     let restore_dns = "cp /etc/resolv.conf.bak /etc/resolv.conf";

--- a/rs-tproxy-proxy/src/handler/http/selector.rs
+++ b/rs-tproxy-proxy/src/handler/http/selector.rs
@@ -57,9 +57,10 @@ pub fn select_response(
 
 #[cfg(test)]
 mod tests {
-    use crate::handler::http::selector::{select_request, Selector};
     use http::Request;
     use hyper::Body;
+
+    use crate::handler::http::selector::{select_request, Selector};
 
     #[test]
     fn test_select_request() {

--- a/tests/integrations/test_uds.rs
+++ b/tests/integrations/test_uds.rs
@@ -1,6 +1,7 @@
+use std::env;
+
 use rs_tproxy_controller_lib::proxy::uds_server::UdsDataServer;
 use rs_tproxy_proxy::uds_client::UdsDataClient;
-use std::env;
 use tokio::time::Duration;
 use uuid::Uuid;
 


### PR DESCRIPTION
The help message in old version will print `Error` ahead of logging help message .
I have tried to run rs-tproxy on centos 8+ & centos 7.9 & ubuntu 20LTS & ubuntu18LTS & Debian 10  , and then I find some problem with ebtables version & 'ip' command version.
I fixed these problem in this pr.

Update doc:
- [x] Add detailed info of config file.