### PR TITLE
Add arp perm rule & flush main ip route for container.

### DIFF
--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -346,7 +346,11 @@ pub fn execute(cmdv: Vec<&str>) -> Result<()> {
     for s in iter {
         cmd.arg(*s);
     }
-    os_err(cmd.output().unwrap().stderr)
+    let out = cmd.output().unwrap();
+    if !out.stdout.is_empty() {
+        tracing::debug!("stdout : {}", String::from_utf8_lossy(&out.stdout));
+    }
+    os_err(out.stderr)
 }
 
 pub fn get_interface(name: String) -> Result<NetworkInterface> {

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -177,7 +177,7 @@ impl NetEnv {
         let interfaces = pnet::datalink::interfaces();
         let index = interfaces
             .iter()
-            .position(|p| &(p.name) == &self.veth4)
+            .position(|p| p.name == self.veth4)
             .unwrap();
         let _ = execute(ip_netns(
             &self.netns,
@@ -194,14 +194,14 @@ impl NetEnv {
         let restore_dns = "cp /etc/resolv.conf.bak /etc/resolv.conf";
         let remove_store = format!("rm -f {}", &self.ip_route_store);
 
-        let flush_main_route = format!("ip route flush table main");
+        let flush_main_route = "ip route flush table main";
 
         let cmdvv = vec![
             ip_netns_del(&self.netns),
             ip_link_del_bridge(&self.bridge1),
             ip_address("add", &self.ip, &self.device),
             bash_c(restore_dns),
-            bash_c(&flush_main_route),
+            bash_c(flush_main_route),
             clear_ebtables(),
         ];
         execute_all_with_log_error(cmdvv)?;

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -180,12 +180,8 @@ impl NetEnv {
     pub fn clear_bridge(&self) -> Result<()> {
         let restore_dns = "cp /etc/resolv.conf.bak /etc/resolv.conf";
         let remove_store = format!("rm -f {}", &self.ip_route_store);
-
-        let net: Ipv4Network = self.ip.parse().unwrap();
-        let net_domain = Ipv4Addr::from(u32::from(net.ip()) & u32::from(net.mask())).to_string()
-            + "/"
-            + &net.prefix().to_string();
-        let del_default_route = format!("ip route del {} dev {} proto kernel scope link src {}", &net_domain, &self.device, &net.ip().to_string());
+        
+        let flush_main_route = format!("ip route flush table main");
         let ip_route_show = "ip route show";
 
         let cmdvv = vec![
@@ -193,7 +189,7 @@ impl NetEnv {
             ip_link_del_bridge(&self.bridge1),
             ip_address("add", &self.ip, &self.device),
             bash_c(restore_dns),
-            bash_c(&del_default_route),
+            bash_c(&flush_main_route),
             clear_ebtables(),
             bash_c(ip_route_show),
         ];

--- a/rs-tproxy-controller/src/proxy/net/bridge.rs
+++ b/rs-tproxy-controller/src/proxy/net/bridge.rs
@@ -186,6 +186,7 @@ impl NetEnv {
             + "/"
             + &net.prefix().to_string();
         let del_default_route = format!("ip route del {} dev {} proto kernel scope link src {}", &net_domain, &self.device, &net.ip().to_string());
+        let ip_route_show = "ip route show";
 
         let cmdvv = vec![
             ip_netns_del(&self.netns),
@@ -194,6 +195,7 @@ impl NetEnv {
             bash_c(restore_dns),
             bash_c(&del_default_route),
             clear_ebtables(),
+            bash_c(ip_route_show),
         ];
         execute_all_with_log_error(cmdvv)?;
 


### PR DESCRIPTION
For [#2555](https://github.com/chaos-mesh/chaos-mesh/pull/2555),
1. in container the ip route changes caused by delete device will be late to some add route operation which will cause XXX exists and make all clear_bridge operations failed -> so I flush the main table before add routes.
2. in container the arp flooding speed is too slow , it will cost 10+mins to flooding all the arp rules -> so I add arp perm rules.

Test done on:

- [x] container
- [x] centos8.2
- [x] debian10.2